### PR TITLE
Optimize module for PHP 8.3 compatibility

### DIFF
--- a/PageUseIdAsName.module.php
+++ b/PageUseIdAsName.module.php
@@ -15,7 +15,7 @@ class PageUseIdAsName extends WireData implements Module, ConfigurableModule
             'singular' => true,
             'autoload' => 'template=admin',
             'requires' => [
-                'PHP>=7.0.0',
+                'PHP>=7.4.0 || ^8.0',
                 'ProcessWire>=3.0.148'
             ]
         );
@@ -91,7 +91,7 @@ class PageUseIdAsName extends WireData implements Module, ConfigurableModule
         $field->label = __('Templates');
         $field->description = __('Choose for which templates the rule should be applied.');
         $field->attr('name', $fieldName);
-        $field->attr('value', isset($data[$fieldName]) ? $data[$fieldName] : null);
+        $field->attr('value', $data[$fieldName] ?? null);
         $field->addOptions($templates);
         $wrapper->append($field);
 
@@ -102,6 +102,6 @@ class PageUseIdAsName extends WireData implements Module, ConfigurableModule
     {
         $fieldName = 'page_use_id_as_name_templates';
         $allowedTemplates = $this->get($fieldName);
-        return in_array($template->id, $allowedTemplates);
+        return is_array($allowedTemplates) && in_array($template->id, $allowedTemplates);
     }
 }

--- a/PageUseIdAsName.module.php
+++ b/PageUseIdAsName.module.php
@@ -10,7 +10,7 @@ class PageUseIdAsName extends WireData implements Module, ConfigurableModule
         return array(
             'title' => 'PageUseIdAsName',
             'class' => 'PageUseIdAsName',
-            'version' => 115,
+            'version' => 120,
             'summary' => 'Overrides the name field (used for url) with the page-id and hides the field from the admin GUI',
             'singular' => true,
             'autoload' => 'template=admin',

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.0 || ^8.0",
         "composer/installers": "~1.0"
     }
 }


### PR DESCRIPTION
This commit introduces changes to enhance compatibility and robustness for PHP 8.0 and newer, including PHP 8.3.

Key changes:
- Updated `composer.json` to specify PHP requirement as `^7.0 || ^8.0`, ensuring broader compatibility while supporting modern PHP versions.
- Refactored `PageUseIdAsName.module.php`:
    - Replaced `isset(...) ? ... : null` with the null coalescing operator (`??`) for cleaner code in `getModuleConfigInputfields()`.
    - Added an `is_array()` check before `in_array()` in `isAllowedTemplate()` to prevent potential errors if module configuration is missing or invalid.
- Updated the PHP requirement within the module's `getModuleInfo()` method to `'PHP>=7.4.0 || ^8.0'`, reflecting support for more recent PHP versions.

These changes aim to ensure the module functions correctly on PHP 8.3 environments and incorporates modern PHP best practices for improved code quality. I recommend that you test this in a PHP 8.3 environment with ProcessWire.